### PR TITLE
(vitineth/permission): adding permission support via keycloak

### DIFF
--- a/uemsCommLib/package.json
+++ b/uemsCommLib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uems/uemscommlib",
-  "version": "0.1.0-beta.47",
+  "version": "0.1.0-beta.48",
   "description": "The common library used by backend elements of the uems system",
   "dependencies": {
     "ajv": "^6.12.3"

--- a/uemsCommLib/package.json
+++ b/uemsCommLib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uems/uemscommlib",
-  "version": "0.1.0-beta.46",
+  "version": "0.1.0-beta.47",
   "description": "The common library used by backend elements of the uems system",
   "dependencies": {
     "ajv": "^6.12.3"

--- a/uemsCommLib/package.json
+++ b/uemsCommLib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uems/uemscommlib",
-  "version": "0.1.0-beta.49",
+  "version": "0.1.0-beta.50",
   "description": "The common library used by backend elements of the uems system",
   "dependencies": {
     "ajv": "^6.12.3"

--- a/uemsCommLib/package.json
+++ b/uemsCommLib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uems/uemscommlib",
-  "version": "0.1.0-beta.48",
+  "version": "0.1.0-beta.49",
   "description": "The common library used by backend elements of the uems system",
   "dependencies": {
     "ajv": "^6.12.3"

--- a/uemsCommLib/src/comment/CommentValidators.ts
+++ b/uemsCommLib/src/comment/CommentValidators.ts
@@ -130,6 +130,11 @@ export namespace CommentValidators {
 	      "type": "string",
           "description": "",
         },
+		  "localAssetOnly": {
+			  "type": "boolean",
+			  "description": "If the query should only create a comment on data created by the user identified by " +
+				  "userID. If anonymous it will do nothing. This refers to the asset, not the comments"
+		  }
 	  }
 	}
 
@@ -140,6 +145,7 @@ export namespace CommentValidators {
 		topic?: string,
 		requiresAttention?: boolean,
         body: string,
+		localAssetOnly?: boolean,
 	};
 	export const COMMENT_READ_SCHEMA = {
 	  "type": "object",

--- a/uemsCommLib/src/comment/CommentValidators.ts
+++ b/uemsCommLib/src/comment/CommentValidators.ts
@@ -184,7 +184,12 @@ export namespace CommentValidators {
 	    "body": {
 	      "type": "string",
           "description": "",
-        }
+        },
+		  "localAssetOnly": {
+			  "type": "boolean",
+			  "description": "If the query should only return data created by the user identified by userID. If " +
+				  "anonymous it will do nothing. This refers to the asset, not the comments"
+		  }
 	  }
 	}
 
@@ -198,6 +203,7 @@ export namespace CommentValidators {
 		requiresAttention?: boolean,
 		attended?: boolean,
         body?: string,
+		localAssetOnly?: boolean,
 	};
 	export const COMMENT_DELETE_SCHEMA = {
 	  "type": "object",
@@ -211,12 +217,18 @@ export namespace CommentValidators {
 	    "id": {
 	      "type": "string",
 	      "description": ""
-	    }
+	    },
+		  "localOnly": {
+			  "type": "boolean",
+			  "description": "If the delete should only affect data created by the user identified by userID. If " +
+				  "anonymous it will perform nothing"
+		  }
 	  }
 	}
 
 	export type CommentDeleteSchema = CoreSchema<'DELETE'> & {
 		id: string,
+		localOnly?: boolean,
 	};
 	export const COMMENT_UPDATE_SCHEMA = {
 	  "type": "object",
@@ -248,6 +260,11 @@ export namespace CommentValidators {
 	        "type": "string",
             "description": "",
         },
+		"localOnly": {
+			"type": "boolean",
+			"description": "If the update should only modify data created by the user identified by userID. If " +
+				"anonymous it will do nothing"
+		}
 	  }
 	}
 
@@ -257,6 +274,7 @@ export namespace CommentValidators {
 		requiresAttention?: boolean,
 		attendedBy?: string,
         body?: string,
+		localOnly?: boolean,
 	};
 	const COMMENT_RESPONSE_OBJECT_SCHEMA = {
 	    "additionalProperties": false,

--- a/uemsCommLib/src/event/EventValidators.ts
+++ b/uemsCommLib/src/event/EventValidators.ts
@@ -236,6 +236,11 @@ export namespace EventValidators {
                     "type": "string",
                     "description": ""
                 }
+            },
+            "localOnly": {
+                "type": "boolean",
+                "description": "If the query should only return data created by the user identified by userID. If " +
+                    "anonymous it will return nothing"
             }
         }
     }
@@ -257,6 +262,7 @@ export namespace EventValidators {
         attendanceRangeEnd?: number,
         allVenues?: string[],
         anyVenues?: string[],
+        localOnly?: boolean,
     };
     export const EVENT_DELETE_SCHEMA = {
         "type": "object",
@@ -270,6 +276,11 @@ export namespace EventValidators {
             "id": {
                 "type": "string",
                 "description": ""
+            },
+            "localOnly": {
+                "type": "boolean",
+                "description": "If the delete should only affect data created by the user identified by userID. If " +
+                    "anonymous it will perform nothing"
             }
         }
     }
@@ -335,6 +346,11 @@ export namespace EventValidators {
             "stateID": {
                 "type": "string",
                 "description": ""
+            },
+            "localOnly": {
+                "type": "boolean",
+                "description": "If the update should only affect data created by the user identified by userID. If " +
+                    "anonymous it will perform nothing"
             }
         }
     }
@@ -350,6 +366,7 @@ export namespace EventValidators {
         removeVenues?: string[],
         entsID?: string,
         stateID?: string,
+        localOnly?: boolean,
     };
     const EVENT_RESPONSE_OBJECT_SCHEMA = {
         "additionalProperties": false,

--- a/uemsCommLib/src/event/EventValidators.ts
+++ b/uemsCommLib/src/event/EventValidators.ts
@@ -3,6 +3,7 @@ import { MessageValidator } from "../messaging/MessageValidator";
 import { VenueValidators } from "../venues/VenueValidators";
 import { EntStateValidators } from "../ent/EntStateValidators";
 import { StateValidators } from "../state/StateValidators";
+import {UserValidators} from "../user/UserValidators";
 
 export namespace EventValidators {
 
@@ -17,6 +18,8 @@ export namespace EventValidators {
     import STATE_REPRESENTATION = StateValidators.STATE_REPRESENTATION;
     import EntStateRepresentation = EntStateValidators.EntStateRepresentation;
     import StateRepresentation = StateValidators.StateRepresentation;
+    import USER_REPRESENTATION = UserValidators.USER_REPRESENTATION;
+    import UserRepresentation = UserValidators.UserRepresentation;
 
     export const EVENT_REPRESENTATION = {
         "type": "object",
@@ -80,6 +83,15 @@ export namespace EventValidators {
                     }
                 ]
             },
+            "author": {
+                "oneOf": [
+                    {...USER_REPRESENTATION},
+                    {
+                        "type": "string",
+                        "description": "",
+                    }
+                ]
+            }
         }
     }
 
@@ -92,12 +104,14 @@ export namespace EventValidators {
         attendance: number,
         ents?: string,
         state?: string,
+        author: string,
     }
 
     export type EventRepresentation = Omit<ShallowEventRepresentation, 'ents' | 'state' | 'venues'> & {
         venues: VenueRepresentation[],
         ents?: EntStateRepresentation,
         state?: StateRepresentation,
+        author: UserRepresentation,
     };
 
     export const EVENT_CREATE_SCHEMA = {

--- a/uemsCommLib/src/event/EventValidators.ts
+++ b/uemsCommLib/src/event/EventValidators.ts
@@ -107,7 +107,7 @@ export namespace EventValidators {
         author: string,
     }
 
-    export type EventRepresentation = Omit<ShallowEventRepresentation, 'ents' | 'state' | 'venues'> & {
+    export type EventRepresentation = Omit<ShallowEventRepresentation, 'ents' | 'state' | 'venues' | 'author'> & {
         venues: VenueRepresentation[],
         ents?: EntStateRepresentation,
         state?: StateRepresentation,

--- a/uemsCommLib/src/file/FileValidators.ts
+++ b/uemsCommLib/src/file/FileValidators.ts
@@ -164,6 +164,11 @@ export namespace FileValidators {
             "userid": {
                 "type": "string",
                 "description": ""
+            },
+            "localOnly": {
+                "type": "boolean",
+                "description": "If the query should only return data created by the user identified by userID. If " +
+                    "anonymous it will return nothing"
             }
         }
     }
@@ -176,6 +181,7 @@ export namespace FileValidators {
         type?: string,
         date?: number,
         userid?: string,
+        localOnly?: boolean,
     };
     export const FILE_DELETE_SCHEMA = {
         "type": "object",

--- a/uemsCommLib/src/filebinding/FileBindingValidators.ts
+++ b/uemsCommLib/src/filebinding/FileBindingValidators.ts
@@ -48,6 +48,11 @@ export namespace FileBindingValidators {
             "fileID": {
                 "type": "string",
                 "description": "The file ID for which to retrieve all events",
+            },
+            "localOnly": {
+                "type": "boolean",
+                "description": "If the query should only return data created by the user identified by userID. If " +
+                    "anonymous it will return nothing"
             }
         }
     }
@@ -78,6 +83,7 @@ export namespace FileBindingValidators {
 
     export type QueryByFileMessage = CoreSchema<'READ'> & {
         fileID: string,
+        localOnly?: boolean,
     }
 
     export type QueryByFileResponse = CoreSchemaWithStatus<'READ'> & {
@@ -102,6 +108,11 @@ export namespace FileBindingValidators {
             "eventID": {
                 "type": "string",
                 "description": "The event ID for which to fetch files",
+            },
+            "localOnly": {
+                "type": "boolean",
+                "description": "If the query should only return data created by the user identified by userID. If " +
+                    "anonymous it will return nothing"
             }
         }
     }
@@ -132,6 +143,7 @@ export namespace FileBindingValidators {
 
     export type QueryByEventMessage = CoreSchema<'READ'> & {
         eventID: string,
+        localOnly?: boolean,
     }
 
     export type QueryByEventResponse = CoreSchemaWithStatus<'READ'> & {
@@ -164,6 +176,11 @@ export namespace FileBindingValidators {
                 "items": {
                     "type": "string",
                 },
+            },
+            "localOnly": {
+                "type": "boolean",
+                "description": "If the update should only modify data created by the user identified by userID. If " +
+                    "anonymous it will do nothing"
             }
         }
     }
@@ -173,6 +190,7 @@ export namespace FileBindingValidators {
     export type BindEventsToFileMessage = CoreSchema<'CREATE'> & {
         fileID: string,
         eventIDs: string[],
+        localOnly?: boolean,
     }
 
     export type BindEventsToFileResponse = CoreSchemaWithStatus<'CREATE'> & {
@@ -201,6 +219,11 @@ export namespace FileBindingValidators {
                     "type": "string",
                 },
                 "description": "The additional file IDs to bind to the event",
+            },
+            "localOnly": {
+                "type": "boolean",
+                "description": "If the update should only modify data created by the user identified by userID. If " +
+                    "anonymous it will do nothing"
             }
         }
     }
@@ -210,6 +233,7 @@ export namespace FileBindingValidators {
     export type BindFilesToEventMessage = CoreSchema<'CREATE'> & {
         eventID: string,
         fileIDs: string[],
+        localOnly?: boolean,
     }
 
     export type BindFilesToEventResponse = CoreSchemaWithStatus<'CREATE'> & {
@@ -239,6 +263,11 @@ export namespace FileBindingValidators {
                     "type": "string",
                 },
                 "description": "The events to remove from this file",
+            },
+            "localOnly": {
+                "type": "boolean",
+                "description": "If the update should only modify data created by the user identified by userID. If " +
+                    "anonymous it will do nothing"
             }
         }
     }
@@ -248,6 +277,7 @@ export namespace FileBindingValidators {
     export type UnbindEventsFromFileMessage = CoreSchema<'DELETE'> & {
         fileID: string,
         eventIDs: string[],
+        localOnly?: boolean,
     }
 
     export type UnbindEventsFromFileResponse = CoreSchemaWithStatus<'DELETE'> & {
@@ -276,6 +306,11 @@ export namespace FileBindingValidators {
                     "type": "string",
                 },
                 "description": "The file ids which should be removed from this event"
+            },
+            "localOnly": {
+                "type": "boolean",
+                "description": "If the update should only modify data created by the user identified by userID. If " +
+                    "anonymous it will do nothing"
             }
         }
     }
@@ -285,6 +320,7 @@ export namespace FileBindingValidators {
     export type UnbindFilesFromEventMessage = CoreSchema<'DELETE'> & {
         eventID: string,
         fileIDs: string[],
+        localOnly?: boolean,
     }
 
     export type UnbindFilesFromEventResponse = CoreSchemaWithStatus<'DELETE'> & {
@@ -314,6 +350,11 @@ export namespace FileBindingValidators {
                     "type": "string",
                 },
                 "description": "The only events to be attached to this file",
+            },
+            "localOnly": {
+                "type": "boolean",
+                "description": "If the update should only modify data created by the user identified by userID. If " +
+                    "anonymous it will do nothing"
             }
         }
     }
@@ -323,6 +364,7 @@ export namespace FileBindingValidators {
     export type SetEventsForFileMessage = CoreSchema<'UPDATE'> & {
         fileID: string,
         eventIDs: string[],
+        localOnly?: boolean,
     }
 
     export type SetEventsForFileResponse = CoreSchemaWithStatus<'UPDATE'> & {
@@ -351,6 +393,11 @@ export namespace FileBindingValidators {
                     "type": "string",
                 },
                 "description": "The only file ids which should be present on this event"
+            },
+            "localOnly": {
+                "type": "boolean",
+                "description": "If the update should only modify data created by the user identified by userID. If " +
+                    "anonymous it will do nothing"
             }
         }
     }
@@ -360,6 +407,7 @@ export namespace FileBindingValidators {
     export type SetFilesForEventMessage = CoreSchema<'UPDATE'> & {
         eventID: string,
         fileIDs: string[],
+        localOnly?: boolean,
     }
 
     export type SetFilesForEventResponse = CoreSchemaWithStatus<'UPDATE'> & {

--- a/uemsCommLib/src/messaging/types/event_message_schema.ts
+++ b/uemsCommLib/src/messaging/types/event_message_schema.ts
@@ -27,7 +27,8 @@ export type ReadEventMsg = {
     event_end_date_range_begin?: UemsDateTime,
     event_end_date_range_end?: UemsDateTime,
     venue_ids?: string[],
-    attendance?: number
+    attendance?: number,
+    localOnly? : boolean,
 };
 
 export type UpdateEventMsg = {
@@ -39,7 +40,8 @@ export type UpdateEventMsg = {
     event_start_date?: UemsDateTime,
     event_end_date?: UemsDateTime,
     venue_ids?: string[],
-    predicted_attendance?: number
+    predicted_attendance?: number,
+    localOnly?: boolean,
 };
 
 export type DeleteEventMsg = {

--- a/uemsCommLib/src/signup/SignupValidators.ts
+++ b/uemsCommLib/src/signup/SignupValidators.ts
@@ -162,12 +162,18 @@ export namespace SignupValidators {
 	    "id": {
 	      "type": "string",
 	      "description": ""
-	    }
+	    },
+		  "localOnly": {
+			  "type": "boolean",
+			  "description": "If the delete should only affect data created by the user identified by userID. If " +
+				  "anonymous it will perform nothing"
+		  }
 	  }
 	}
 
 	export type SignupDeleteSchema = CoreSchema<'DELETE'> & {
 		id: string,
+		localOnly?: boolean,
 	};
 	export const SIGNUP_UPDATE_SCHEMA = {
 	  "type": "object",
@@ -186,13 +192,19 @@ export namespace SignupValidators {
 	    "role": {
 	      "type": "string",
 	      "description": ""
-	    }
+	    },
+		  "localOnly": {
+			  "type": "boolean",
+			  "description": "If the delete should only affect data created by the user identified by userID. If " +
+				  "anonymous it will perform nothing"
+		  }
 	  }
 	}
 
 	export type SignupUpdateSchema = CoreSchema<'UPDATE'> & {
 		id: string,
 		role?: string,
+		localOnly?: boolean,
 	};
 	const SIGNUP_RESPONSE_OBJECT_SCHEMA = {
 	    "additionalProperties": false,


### PR DESCRIPTION
This integrates role based permissions as defined in keycloak. Four roles are defined
* admin
* extended
* ops
* ents

Admin should have permission to do everything on the system. Ops are allowed to manage venues, states, etc. Ents can view everything and are allowed to access the equipment regions. Extended is reserved for users between normal and ents where they can see all without editing anything. This will need to be updated later if required. 