### PR TITLE
(vitineth/permissions): signup delete permission upgrade

### DIFF
--- a/docker-setup/mongo-seeding/seed-mongo-uems.py
+++ b/docker-setup/mongo-seeding/seed-mongo-uems.py
@@ -105,12 +105,12 @@ class EventDetailsSeeder:
                 'username': fake.user_name()
             }]
 
-        uids += ['auth0|5ffa3483c18deb006850f0c6']
+        uids += ['b795317b-d0f3-4b62-b0e3-2383ae225433']
         elements += [{
             'email': 'vitineth@gmail.com',
             'hash': '',
             'name': 'Ryan Delaney',
-            'uid': 'auth0|5ffa3483c18deb006850f0c6',
+            'uid': 'b795317b-d0f3-4b62-b0e3-2383ae225433',
             'username': 'vitineth'
         }]
 
@@ -139,7 +139,7 @@ class EventDetailsSeeder:
         # Skipped for now until I can create files in the docker container
         pass
 
-    def seed_events(self, venue_ids, state_ids, ents_ids):
+    def seed_events(self, venue_ids, state_ids, ents_ids, user_ids):
         db = self.client.events
         details = db.details
 
@@ -156,7 +156,8 @@ class EventDetailsSeeder:
                 'name': fake.word(),
                 'start': (s - datetime.datetime.utcfromtimestamp(0)).total_seconds(),
                 'state': fake.random_element(state_ids),
-                'venues': fake.random_choices(venue_ids)
+                'venues': fake.random_choices(venue_ids),
+                'author': fake.random_element(user_ids)
             }]
 
         return [str(x) for x in details.insert_many(elements).inserted_ids]
@@ -202,7 +203,7 @@ class EventDetailsSeeder:
         topics = self.seed_topic_states()
         users = self.seed_users()
         venues = self.seed_venues(users)
-        events = self.seed_events(venues, states, ents)
+        events = self.seed_events(venues, states, ents, users)
         comments = self.seed_event_comments(events, topics, users)
         signups = self.seed_signups(events, users)
         print('Done')

--- a/uemsCommLib/package.json
+++ b/uemsCommLib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uems/uemscommlib",
-  "version": "0.1.0-beta.50",
+  "version": "0.1.0-beta.51",
   "description": "The common library used by backend elements of the uems system",
   "dependencies": {
     "ajv": "^6.12.3"

--- a/uemsCommLib/src/discovery/DiscoveryValidators.ts
+++ b/uemsCommLib/src/discovery/DiscoveryValidators.ts
@@ -44,6 +44,11 @@ export namespace DiscoveryValidators{
                 "type": "string",
                 "description": "The ID of the asset being requested for deletion",
             },
+            "localAssetOnly": {
+                "type": "boolean",
+                "description": "If the query should only reference data created by the user identified by userID. If " +
+                    "anonymous it will do nothing"
+            },
             ...CORE_SCHEMA('READ'),
         },
         "not": {
@@ -75,6 +80,7 @@ export namespace DiscoveryValidators{
         assetType: 'equipment' | 'event' | 'signup' | 'event.comment' | 'file' | 'file.binding'
         | 'ent' | 'topic' | 'state' | 'user' | 'venue',
         assetID: string,
+        localAssetOnly?: boolean,
     } & Record<Sub<string, 'execute'>, any>;
 
     export type DeleteRequest = CoreSchema<'READ'> & {
@@ -82,6 +88,7 @@ export namespace DiscoveryValidators{
             | 'ent' | 'topic' | 'state' | 'user' | 'venue',
         assetID: string,
         execute: true,
+        localAssetOnly?: boolean,
     } & Record<string, any>;
 
     export const DISCOVERY_REPLY = {


### PR DESCRIPTION
The delete signup permission route did not have all the permissions required. This adds local only filtering to discovery and delete messages. This is only implemented on signups, however. 