### PR TITLE
(vitineth/feature/workflow): adding ops planning workflow with additional upgrades

### DIFF
--- a/uemsCommLib/package.json
+++ b/uemsCommLib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uems/uemscommlib",
-  "version": "0.1.0-beta.55",
+  "version": "0.1.0-beta.56",
   "description": "The common library used by backend elements of the uems system",
   "dependencies": {
     "ajv": "^6.12.3"

--- a/uemsCommLib/package.json
+++ b/uemsCommLib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uems/uemscommlib",
-  "version": "0.1.0-beta.54",
+  "version": "0.1.0-beta.55",
   "description": "The common library used by backend elements of the uems system",
   "dependencies": {
     "ajv": "^6.12.3"

--- a/uemsCommLib/package.json
+++ b/uemsCommLib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uems/uemscommlib",
-  "version": "0.1.0-beta.52",
+  "version": "0.1.0-beta.53",
   "description": "The common library used by backend elements of the uems system",
   "dependencies": {
     "ajv": "^6.12.3"

--- a/uemsCommLib/package.json
+++ b/uemsCommLib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uems/uemscommlib",
-  "version": "0.1.0-beta.53",
+  "version": "0.1.0-beta.54",
   "description": "The common library used by backend elements of the uems system",
   "dependencies": {
     "ajv": "^6.12.3"

--- a/uemsCommLib/src/BaseSchema.ts
+++ b/uemsCommLib/src/BaseSchema.ts
@@ -37,6 +37,10 @@ export namespace BaseSchema {
         "userID": {
             "type": "string",
             "description": "The user ID of the user currently making this request or anonymous if there is no user",
+        },
+        "requestID": {
+            "type": "string",
+            "description": "The request which originated this request to be used for correlational debugging"
         }
     })
 
@@ -56,6 +60,7 @@ export namespace BaseSchema {
         msg_intention: T,
         status: 0,
         userID: 'anonymous' | string,
+        requestID?: string,
     }
 
     /**

--- a/uemsCommLib/src/event/EventValidators.ts
+++ b/uemsCommLib/src/event/EventValidators.ts
@@ -255,6 +255,13 @@ export namespace EventValidators {
                 "type": "boolean",
                 "description": "If the query should only return data created by the user identified by userID. If " +
                     "anonymous it will return nothing"
+            },
+            "stateIn": {
+                "typ": "array",
+                "items": {
+                    "type": "string",
+                    "description": "Returns all events which have a state matching those in this array",
+                }
             }
         }
     }
@@ -277,6 +284,7 @@ export namespace EventValidators {
         allVenues?: string[],
         anyVenues?: string[],
         localOnly?: boolean,
+        stateIn?: string[],
     };
     export const EVENT_DELETE_SCHEMA = {
         "type": "object",

--- a/uemsCommLib/src/event/EventValidators.ts
+++ b/uemsCommLib/src/event/EventValidators.ts
@@ -91,6 +91,10 @@ export namespace EventValidators {
                         "description": "",
                     }
                 ]
+            },
+            "reserved": {
+                "type": "boolean",
+                "description": "Whether this event has reserved the time slot in which it is booked"
             }
         }
     }
@@ -105,6 +109,7 @@ export namespace EventValidators {
         ents?: string,
         state?: string,
         author: string,
+        reserved?: boolean,
     }
 
     export type EventRepresentation = Omit<ShallowEventRepresentation, 'ents' | 'state' | 'venues' | 'author'> & {
@@ -157,6 +162,10 @@ export namespace EventValidators {
             "stateID": {
                 "type": "string",
                 "description": ""
+            },
+            "reserved": {
+                "type": "boolean",
+                "description": "Whether this event has reserved the time slot in which it is booked"
             }
         }
     }
@@ -169,6 +178,7 @@ export namespace EventValidators {
         venueIDs: string[],
         entsID?: string,
         stateID?: string,
+        reserved?: boolean,
     };
     export const EVENT_READ_SCHEMA = {
         "type": "object",
@@ -275,6 +285,10 @@ export namespace EventValidators {
                     "type": "string",
                     "description": "Returns all events which have a state matching those in this array",
                 }
+            },
+            "reserved": {
+                "type": "boolean",
+                "description": "Whether this event has reserved the time slot in which it is booked"
             }
         }
     }
@@ -302,6 +316,7 @@ export namespace EventValidators {
         anyVenues?: string[],
         localOnly?: boolean,
         stateIn?: string[],
+        reserved?: boolean,
     };
     export const EVENT_DELETE_SCHEMA = {
         "type": "object",
@@ -390,6 +405,10 @@ export namespace EventValidators {
                 "type": "boolean",
                 "description": "If the update should only affect data created by the user identified by userID. If " +
                     "anonymous it will perform nothing"
+            },
+            "reserved": {
+                "type": "boolean",
+                "description": "Whether this event has reserved the time slot in which it is booked"
             }
         }
     }
@@ -406,6 +425,7 @@ export namespace EventValidators {
         entsID?: string,
         stateID?: string,
         localOnly?: boolean,
+        reserved?: boolean,
     };
     const EVENT_RESPONSE_OBJECT_SCHEMA = {
         "additionalProperties": false,

--- a/uemsCommLib/src/event/EventValidators.ts
+++ b/uemsCommLib/src/event/EventValidators.ts
@@ -229,6 +229,19 @@ export namespace EventValidators {
                 "type": "number",
                 "description": ""
             },
+            "coincidesWith": {
+                "type": "object",
+                "required": ["start", "end"],
+                "additionalProperties": false,
+                "properties": {
+                    "start": {
+                        "type": "number",
+                    },
+                    "end": {
+                        "type": "number",
+                    }
+                }
+            },
             "attendanceRangeBegin": {
                 "type": "number",
                 "description": ""
@@ -279,6 +292,10 @@ export namespace EventValidators {
         startRangeEnd?: number,
         endRangeBegin?: number,
         endRangeEnd?: number,
+        coincidesWith?: {
+            start: number,
+            end: number,
+        },
         attendanceRangeBegin?: number,
         attendanceRangeEnd?: number,
         allVenues?: string[],


### PR DESCRIPTION
Across all elements this includes:

## [hub](https://github.com/ents-crew/uems-hub)
* Added requestID to all internal messages
  * Request logging is working well!

## [events](https://github.com/ents-crew/uems-event-micro-dionysus)
* Adds support for searching by state set
  * This now allows you to specify an array of states and return events which contain at least one of those states. This is used to back the ops planning workflow to retrieve all events based on their states
* Adding event reservation support
  * This allows events to be submitted but not reserve the space. This is not rolled out fully into the system yet and needs some integration into the frontend and when the admin interface gets built there will be a default option. This will allow it to either act like the old system (anyone can book overlapping events) or like the new system (a booking request reserved the space)
* Integrates an entire new AMQPlib based logging system
  * This is presently integrated with greylog locally but could be linked into any system - there is no official solution here. 
* Adding request ID to logging
  * This allows correlational tracking through all services

## [frontend](https://github.com/ents-crew/uems-frontend-themis)
* Adds ops planning workflow
  * This will list all records that are in the review states or do not have the space reserved. 
* Adds new calendar to the frontend
  * This new calendar models the google calendar layout including record stacking and seems to work pretty well. This will allow you to get a better overview. This needs some additional tweaks to integrate more fully
* Makes frontend more modular for events and venues
  * This allows displaying an already loaded element, not pulling it again from the API. This needs to be rolled out further to other view pages but is working well
* Adds venue chips to the frontend
  * Name describes them, a better way to view the venues on the event view pages and more
* Removes user linking from comments
  * User pages are not important and have been removed from the plans from the time being
* Remedies tab pane sizing on frontend
  * They now fill the page

## [gateway](https://github.com/ents-crew/uems-gateway)
* Adding configuration to gateway
  * Configuration is backed by mongodb in a new collection.
* Adding review states with associated routes
  * Review states are added into the configuration in the database and there is a general config object through which these values will be pulled. It only has get paths right now, these will be extended further when the admin interface is built
* Adding basic request caching to speed up loading
  * This is not an ideal solution but caching will be a bigger job so needs to be moved over to a new feature branch